### PR TITLE
修复了一个诡异的bug

### DIFF
--- a/funcat/func.py
+++ b/funcat/func.py
@@ -28,7 +28,7 @@ class OneArgumentSeries(NumericSeries):
 
             try:
                 series[series == np.inf] = np.nan
-                series = self.func(series, arg)
+                series = self.__class__.func(series, arg)
             except Exception as e:
                 raise FormulaException(e)
         super(OneArgumentSeries, self).__init__(series)


### PR DESCRIPTION
运行 tests/test_api.py 中的 test_000001() 会报出如下错误（rqalpha也是因为该错误不能通过测试），修改后该错误不再出现，虽然我非常疑惑这是为什么。。。
```
Traceback (most recent call last):
  File "/Users/cuiziqi/anaconda3/envs/rqa/lib/python3.4/site-packages/talib/__init__.py", line 20, in wrapper
    for arg in chain(args, kwargs.values())
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/cuiziqi/OneDrive/Workspace/funcat/funcat/func.py", line 31, in __init__
    series = self.func(series, arg)
  File "/Users/cuiziqi/anaconda3/envs/rqa/lib/python3.4/site-packages/talib/__init__.py", line 24, in wrapper
    return func(*args, **kwargs)
  File "talib/_func.pxi", line 7863, in talib._ta_lib.MA
TypeError: only size-1 arrays can be converted to Python scalars

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test_api.py", line 29, in <module>
    test_000001()
  File "test_api.py", line 22, in test_000001
    assert np.equal(round(MA(CLOSE, 60)[2].value, 2), 3131.08)
  File "/Users/cuiziqi/OneDrive/Workspace/funcat/funcat/func.py", line 33, in __init__
    raise FormulaException(e)
funcat.utils.FormulaException: only size-1 arrays can be converted to Python scalars
```