### PR TITLE
Fix setup.py script.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ from setuptools import (
     setup,
 )
 
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 
 with open(join(dirname(__file__), 'funcat/VERSION.txt'), 'rb') as f:


### PR DESCRIPTION
There's a breaking change in pip 10. This commit modifies setup.py to
make it compatible.

See https://stackoverflow.com/questions/25192794/no-module-named-pip-req